### PR TITLE
Adding fix for GD build due to PHP 7.4 changes

### DIFF
--- a/fpm.Dockerfile
+++ b/fpm.Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
     zlib1g-dev \
     libzip-dev \
   && rm -rf /var/lib/apt/lists/* \
-  && docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \
+  && docker-php-ext-configure gd --with-jpeg \
   && docker-php-ext-install -j$(nproc) gd \
   && docker-php-ext-install exif \
   && docker-php-ext-install zip


### PR DESCRIPTION
Due to changes in PHP 7.4, the build of GD changed and thus broke the FPM docker build. This fixes that, which I believe also solves #5 too.

More info here: https://github.com/docker-library/php/issues/912